### PR TITLE
Build failure on macOS 15.4 with Xcode 16.3

### DIFF
--- a/deps/sqlite3.gyp
+++ b/deps/sqlite3.gyp
@@ -54,7 +54,7 @@
       },
       'cflags': ['-std=c99', '-w', '-maes', '-msse4.2'],
       'xcode_settings': {
-        'OTHER_CFLAGS': ['-std=c99', '-maes', '-msse4.2'],
+        'OTHER_CFLAGS': ['-std=c99', '-msse4.2'],
         'WARNING_CFLAGS': ['-w'],
       },
       'conditions': [


### PR DESCRIPTION
Thank you for this wonderful project.

Since updating to macOS 15.4 and Xcode 16.3 the build fails during the install phase with

```
error /Users/someone/Projects/typescript/1.5/development/cs-frontend/node_modules/better-sqlite3-multiple-ciphers: Command failed.
Exit code: 1
Command: prebuild-install || node-gyp rebuild --release
Arguments: 
Directory: /Users/someone/Projects/typescript/1.5/development/cs-frontend/node_modules/better-sqlite3-multiple-ciphers
Output:
/bin/sh: prebuild-install: command not found
gyp info it worked if it ends with ok
gyp info using node-gyp@11.2.0
gyp info using node@18.20.8 | darwin | arm64
gyp info find Python using Python version 3.10.16 found at "/opt/homebrew/opt/python@3.10/bin/python3.10"

gyp info spawn /opt/homebrew/opt/python@3.10/bin/python3.10
gyp info spawn args [
gyp info spawn args '/opt/homebrew/lib/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args 'binding.gyp',
gyp info spawn args '-f',
gyp info spawn args 'make',
gyp info spawn args '-I',
gyp info spawn args '/Users/someone/Projects/typescript/1.5/development/cs-frontend/node_modules/better-sqlite3-multiple-ciphers/build/config.gypi',
gyp info spawn args '-I',
gyp info spawn args '/opt/homebrew/lib/node_modules/node-gyp/addon.gypi',
gyp info spawn args '-I',
gyp info spawn args '/Users/someone/Library/Caches/node-gyp/18.20.8/include/node/common.gypi',
gyp info spawn args '-Dlibrary=shared_library',
gyp info spawn args '-Dvisibility=default',
gyp info spawn args '-Dnode_root_dir=/Users/someone/Library/Caches/node-gyp/18.20.8',
gyp info spawn args '-Dnode_gyp_dir=/opt/homebrew/lib/node_modules/node-gyp',
gyp info spawn args '-Dnode_lib_file=/Users/someone/Library/Caches/node-gyp/18.20.8/<(target_arch)/node.lib',
gyp info spawn args '-Dmodule_root_dir=/Users/someone/Projects/typescript/1.5/development/cs-frontend/node_modules/better-sqlite3-multiple-ciphers',
gyp info spawn args '-Dnode_engine=v8',
gyp info spawn args '--depth=.',
gyp info spawn args '--no-parallel',
gyp info spawn args '--generator-output',
gyp info spawn args 'build',
gyp info spawn args '-Goutput_dir=.'
gyp info spawn args ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  TOUCH ba23eeee118cd63e16015df367567cb043fed872.intermediate
  ACTION deps_sqlite3_gyp_locate_sqlite3_target_copy_builtin_sqlite3 ba23eeee118cd63e16015df367567cb043fed872.intermediate
  TOUCH Release/obj.target/deps/locate_sqlite3.stamp
  CC(target) Release/obj.target/sqlite3/gen/sqlite3/sqlite3.o
clang: error: unsupported option '-maes' for target 'arm64-apple-darwin24.4.0'
make: *** [Release/obj.target/sqlite3/gen/sqlite3/sqlite3.o] Error 1
rm ba23eeee118cd63e16015df367567cb043fed872.intermediate
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack at ChildProcess.<anonymous> (/opt/homebrew/lib/node_modules/node-gyp/lib/build.js:219:23)
gyp ERR! System Darwin 24.4.0
gyp ERR! command "/opt/homebrew/Cellar/node@18/18.20.8/bin/node" "/opt/homebrew/lib/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--release"
gyp ERR! cwd /Users/someone/Projects/typescript/1.5/development/cs-frontend/node_modules/better-sqlite3-multiple-ciphers
```

My clang version is

```
$ clang --version
Apple clang version 17.0.0 (clang-1700.0.13.3)
Target: arm64-apple-darwin24.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

```

Yes my node version is outdated, but upgrading didn't fix the issue.

My pull request fixes the build and doesn't seem to break windows and linux.

I do not know if this will introduce performance regressions, so this is by no means ready to be merged to upstream. I just wanted to share so it might save someone else some time.