### PR TITLE
Fix build against Electron 42 / V8 14.8

### DIFF
--- a/src/better_sqlite3.cpp
+++ b/src/better_sqlite3.cpp
@@ -8,6 +8,10 @@
 #include <algorithm>
 #include <mutex>
 #include <sqlite3.h>
+#if defined(_MSC_VER) && !defined(__clang__) && !defined(__builtin_frame_address)
+#include <intrin.h>
+#define __builtin_frame_address(level) _AddressOfReturnAddress()
+#endif
 #include <node.h>
 #include <node_object_wrap.h>
 #include <node_buffer.h>
@@ -57,7 +61,7 @@ NODE_MODULE_INIT(/* exports, context */) {
 
 	// Initialize addon instance.
 	Addon* addon = new Addon(isolate);
-	v8::Local<v8::External> data = v8::External::New(isolate, addon);
+	v8::Local<v8::External> data = NewExternal(isolate, addon);
 	node::AddEnvironmentCleanupHook(isolate, Addon::Cleanup, addon);
 
 	// Create and export native-backed classes and functions.

--- a/src/util/helpers.cpp
+++ b/src/util/helpers.cpp
@@ -19,6 +19,24 @@ inline void SetFrozen(v8::Isolate* isolate, v8::Local<v8::Context> ctx, v8::Loca
 	obj->DefineOwnProperty(ctx, key.Get(isolate), value, static_cast<v8::PropertyAttribute>(v8::DontDelete | v8::ReadOnly)).FromJust();
 }
 
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 14 || (V8_MAJOR_VERSION == 14 && V8_MINOR_VERSION >= 8))
+inline v8::Local<v8::External> NewExternal(v8::Isolate* isolate, void* value) {
+	return v8::External::New(isolate, value, v8::kExternalPointerTypeTagDefault);
+}
+
+inline void* ExternalValue(v8::Local<v8::External> external) {
+	return external->Value(v8::kExternalPointerTypeTagDefault);
+}
+#else
+inline v8::Local<v8::External> NewExternal(v8::Isolate* isolate, void* value) {
+	return v8::External::New(isolate, value);
+}
+
+inline void* ExternalValue(v8::Local<v8::External> external) {
+	return external->Value();
+}
+#endif
+
 void ThrowError(const char* message) { EasyIsolate; isolate->ThrowException(v8::Exception::Error(StringFromUtf8(isolate, message, -1))); }
 void ThrowTypeError(const char* message) { EasyIsolate; isolate->ThrowException(v8::Exception::TypeError(StringFromUtf8(isolate, message, -1))); }
 void ThrowRangeError(const char* message) { EasyIsolate; isolate->ThrowException(v8::Exception::RangeError(StringFromUtf8(isolate, message, -1))); }
@@ -89,7 +107,7 @@ void SetPrototypeGetter(
 	recv->InstanceTemplate()->SetNativeDataProperty(
 		InternalizedFromLatin1(isolate, name),
 		func,
-		0,
+		static_cast<v8::AccessorNameSetterCallback>(nullptr),
 		data
 	);
 }

--- a/src/util/macros.cpp
+++ b/src/util/macros.cpp
@@ -27,7 +27,7 @@
 #define EasyIsolate v8::Isolate* isolate = v8::Isolate::GetCurrent()
 #define OnlyIsolate info.GetIsolate()
 #define OnlyContext isolate->GetCurrentContext()
-#define OnlyAddon static_cast<Addon*>(info.Data().As<v8::External>()->Value())
+#define OnlyAddon static_cast<Addon*>(ExternalValue(info.Data().As<v8::External>()))
 #define UseIsolate v8::Isolate* isolate = OnlyIsolate
 #define UseContext v8::Local<v8::Context> ctx = OnlyContext
 #define UseAddon Addon* addon = OnlyAddon


### PR DESCRIPTION
## Summary

- Add compatibility wrappers for V8 14.8's tagged `v8::External::New()` / `Value()` APIs.
- Disambiguate `SetNativeDataProperty()`'s null setter argument for newer V8 overloads.
- Provide an MSVC fallback for `__builtin_frame_address()` before including Electron 42's cppgc headers.

## Verification

- `npm run build-release` on Node v24.15.0 / Windows x64
- `npx --yes node-gyp rebuild --release --target=42.2.0 --arch=x64 --dist-url=https://electronjs.org/headers`
- `npm test` (329 passing, 1 pending)

Note: this repository does not currently have pnpm metadata or a pnpm lockfile, so there was no pnpm version pin to update in the upstream package itself.